### PR TITLE
Allow limiting running time of binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,19 @@ check the [`4.2. Explanation of error messages from Memcheck`](https://valgrind.
         #
         # Default: false
         verbose: false
+
+        # Limit the amount of time Valgrind runs before stopping the binary,
+        # specified in floating point with an optional suffix. A duration of 0
+        # disables the timeout.
+        #
+        # This can be useful to test or bound a long-running process.
+        #
+        # Optional suffix:
+        # - 's' for seconds (the default)
+        # - 'm' for minutes
+        # - 'h' for hours
+        # - 'd' for days
+        #
+        # Default: 0s
+        timeout: 0s
 ```

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: "Asking Valgrind to be verbose"
     required: false
     default: false
+  timeout:
+    description: "Limit running time of the binary"
+    required: false
+    default: 0
 
 runs:
   using: "docker"

--- a/valgrind.bash
+++ b/valgrind.bash
@@ -84,7 +84,9 @@ main() {
     if [[ "${INPUT_LD_LIBRARY_PATH}" == "" ]]; then
         export LD_LIBRARY_PATH="${INPUT_LD_LIBRARY_PATH}"
     fi
-    valgrind $VALGRIND_FLAGS "${INPUT_BINARY_PATH}" $INPUT_BINARY_ARGS 2>"${VALGRIND_REPORTS}"
+    set +e
+    timeout ${INPUT_TIMEOUT} valgrind $VALGRIND_FLAGS "${INPUT_BINARY_PATH}" $INPUT_BINARY_ARGS 2>"${VALGRIND_REPORTS}"
+    set -e
     parse_valgrind_reports "${VALGRIND_REPORTS}"
 }
 


### PR DESCRIPTION
Hello,

I found a use case of running Valgrind against a daemonized binary, which doesn't terminate on its own by design. By leveraging `timeout`, we can enable running this binary for some amount of time to perform analysis within Github Actions.

There may be a better approach, but this worked for my use case. 

The extra `set` commands handle the non-zero exit status for a command that has been timed out.